### PR TITLE
test script

### DIFF
--- a/PathKit/package.json
+++ b/PathKit/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "lint": "eslint --fix main.js",
     "format": "prettier -w .",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.0",


### PR DESCRIPTION
adds a new command line option to npm: `npm run test`, which runs all of the vitest tests