### PR TITLE
remove accidental filter to tests

### DIFF
--- a/.github/workflows/verify_frontend.yml
+++ b/.github/workflows/verify_frontend.yml
@@ -27,4 +27,4 @@ jobs:
         npm install
         npm run build
         npm run tauri build
-        npm run test run a
+        npm run test run


### PR DESCRIPTION
## Description

There was a sneaky filter that was accidentally only testing files with "a" in their name

## Does this fix an existing issue?

no

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation: TBD
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [x] I will put an appropriate label on my pull request
